### PR TITLE
Bump openssl to 1.0.2k

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -12,16 +12,16 @@ lzo/lzo.tar.gz.sha256sum:
   sha: 1506980b73da643530412323bd8d0422eb36c7e7
 openssl/VERSION:
   size: 7
-  object_id: 65807ba9-c76e-46d5-4f63-0e1b75d1b4b4
-  sha: 4572e32f26206d73db86de8c140bea8dd9817e98
+  object_id: 6c7acf2d-0e7a-4877-69c7-96012926bce0
+  sha: b6dc34d82f3a7212eeca6b2402ca5a495e18047a
 openssl/openssl.tar.gz:
-  size: 5307912
-  object_id: 7a1aa148-6477-44ad-51d1-70e41d3b814d
-  sha: bdfbdb416942f666865fa48fe13c2d0e588df54f
+  size: 5309236
+  object_id: ba27dc04-cbd4-43ad-612b-d78c8261ec66
+  sha: 5f26a624479c51847ebd2f22bb9f84b3b44dcb44
 openssl/openssl.tar.gz.asc:
-  size: 473
-  object_id: b52491f6-7b42-454d-6690-fa88a3194b79
-  sha: 111eb6befb4561c14137b1b36db0ba8988c0ee87
+  size: 455
+  object_id: b4a1987c-1e10-4b21-607f-162c733189f1
+  sha: 8a0e10287f55529f1bbe582ea634b3f414b42eb5
 openvpn/VERSION:
   size: 7
   object_id: 98ada45e-13c8-4a61-7604-7c73b178178b


### PR DESCRIPTION
Looks like it already passes tests. When merging, remember to...

 - [x] review the changelog for unexpected feature changes
 - [x] bump the major or minor version for the pipeline, if necessary
 - [x] merge
 - [x] delete the branch