### PR TITLE
Support pushing DNS settings to VPN clients

### DIFF
--- a/jobs/openvpn/spec
+++ b/jobs/openvpn/spec
@@ -48,6 +48,21 @@ properties:
     type: "string[]"
     help: |
           These should be in a format similar to "192.0.2.0 255.255.255.0".
+  openvpn.push_dns:
+    default: []
+    description: "DNS servers to push to connecting clients"
+    type: "string[]"
+    help: |
+          This should be a list of DNS server IP adddresses that should be pushed to
+          connecting clients to enable DNS resolution over the VPN tunnel.
+  openvpn.push_dns_search_domains:
+    default: []
+    description: "List of search domains to push to clients"
+    type: "string[]"
+    help: |
+          This should be a list of domains that should be pushed to connecting clients
+          for use as DNS search domains.
+
   openvpn.cipher:
     description: "Cipher for encrypting packets"
     default: "BF-CBC"

--- a/jobs/openvpn/templates/etc/openvpn.conf.erb
+++ b/jobs/openvpn/templates/etc/openvpn.conf.erb
@@ -26,6 +26,12 @@ server <%= p('openvpn.server') %>
 <% p('openvpn.push_routes').each do | route | %>
 push "route <%= route %>"
 <% end %>
+<% p('openvpn.push_dns').each do |dns| %>
+push "dhcp-option DNS <%= dns %>"
+<% end %>
+<% if_p('openvpn.push_dns_search_domains') do |domains| %>
+push "dhcp-option DOMAIN-SEARCH <%= domains.join(" ") %>"
+<% end %>
 <% p('openvpn.routes').each do | route | %>
 route <%= route %>
 <% end %>

--- a/jobs/openvpn/templates/etc/openvpn.conf.erb
+++ b/jobs/openvpn/templates/etc/openvpn.conf.erb
@@ -31,8 +31,9 @@ push "route <%= route %>"
 push "route <%= dns %> 255.255.255.255"
 push "dhcp-option DNS <%= dns %>"
 <% end %>
-<% if_p('openvpn.push_dns_search_domains') do |domains| %>
-push "dhcp-option DOMAIN-SEARCH <%= domains.join(" ") %>"
+<% p('openvpn.push_dns_search_domains').each do |domain| %>
+push "dhcp-option DOMAIN <%= domain %>"
+push "dhcp-option DOMAIN-SEARCH <%= domain %>"
 <% end %>
 <% p('openvpn.routes').each do | route | %>
 route <%= route %>

--- a/jobs/openvpn/templates/etc/openvpn.conf.erb
+++ b/jobs/openvpn/templates/etc/openvpn.conf.erb
@@ -27,6 +27,8 @@ server <%= p('openvpn.server') %>
 push "route <%= route %>"
 <% end %>
 <% p('openvpn.push_dns').each do |dns| %>
+# ensure we can route to the DNS server over the connection
+push "route <%= dns %> 255.255.255.255"
 push "dhcp-option DNS <%= dns %>"
 <% end %>
 <% if_p('openvpn.push_dns_search_domains') do |domains| %>


### PR DESCRIPTION
Adds support for `openvpn.push_dns` and `openvpn.push_dns_search_domains`, to allow OpenVPN servers to push DNS related settings to clients. 