### PR TITLE
Use release version 4.1.0 in deployments

### DIFF
--- a/deployment/init-aws.yml
+++ b/deployment/init-aws.yml
@@ -2,14 +2,14 @@
   path: /releases/-
   value:
     name: bosh-aws-cpi
-    version: 65
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=65
-    sha1: 26b3a5c43e6f82594a373309a495660d6db26254
+    version: 67
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=67
+    sha1: cfcbc98affa9cad674087ab6b8bd4b1188b18439
 - type: replace
   path: /resource_pools/name=default/stemcell?
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3421.11
-    sha1: 98f9b71398f0f771e8a4bbaf5531440b99bae540
+    url: https://s3.amazonaws.com/bosh-aws-light-stemcells/light-bosh-stemcell-3468.1-aws-xen-hvm-ubuntu-trusty-go_agent.tgz
+    sha1: 741c71747118200c9251545883e184c43c059da9
 - type: replace
   path: /resource_pools/name=default/cloud_properties?
   value:

--- a/deployment/init-google.yml
+++ b/deployment/init-google.yml
@@ -8,8 +8,8 @@
 - type: replace
   path: /resource_pools/name=default/stemcell?
   value:
-    url: https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent?v=3421.9
-    sha1: 408f78a2091d108bb5418964026e73c822def32d
+    url: https://s3.amazonaws.com/bosh-gce-light-stemcells/light-bosh-stemcell-3468.1-google-kvm-ubuntu-trusty-go_agent.tgz
+    sha1: e7ec554900af7140d8e947f629af5d5c0a9defc3
 - type: replace
   path: /resource_pools/name=default/cloud_properties?
   value:

--- a/deployment/openvpn.yml
+++ b/deployment/openvpn.yml
@@ -2,8 +2,8 @@
 name: openvpn
 releases:
 - name: openvpn
-  url: https://s3-external-1.amazonaws.com/dpb587-bosh-release-openvpn-us-east-1/compiled_releases/openvpn/openvpn-4.0.0-on-ubuntu-trusty-stemcell-3421.11-compiled-1.20170630134749.0.tgz
-  sha1: 19e79e45b690bc933b0ff5d9e54574f25d0899b9
+  url: https://s3-external-1.amazonaws.com/dpb587-bosh-release-openvpn-us-east-1/compiled_releases/openvpn/openvpn-4.1.0-on-ubuntu-trusty-stemcell-3468-compiled-1.20171017141355.0.tgz
+  sha1: 3ddea18dcf1710fd8034a7f073410e8cf5e82fb7
 - name: os-conf
   version: 11
   url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=11

--- a/deployment/openvpn.yml
+++ b/deployment/openvpn.yml
@@ -2,8 +2,8 @@
 name: openvpn
 releases:
 - name: openvpn
-  url: https://s3-external-1.amazonaws.com/dpb587-bosh-release-openvpn-us-east-1/compiled_releases/openvpn/openvpn-4.1.0-on-ubuntu-trusty-stemcell-3468-compiled-1.20171017141355.0.tgz
-  sha1: 3ddea18dcf1710fd8034a7f073410e8cf5e82fb7
+  url: https://s3-external-1.amazonaws.com/dpb587-bosh-release-openvpn-us-east-1/compiled_releases/openvpn/openvpn-4.1.0-on-ubuntu-trusty-stemcell-3468.1-compiled-1.20171026070713.0.tgz
+  sha1: aaf081d1a2637dd47b35f5445b70cc3551edb63a
 - name: os-conf
   version: 11
   url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=11

--- a/deployment/openvpn.yml
+++ b/deployment/openvpn.yml
@@ -78,10 +78,15 @@ cloud_provider:
 variables:
 - name: mbus_password
   type: password
-- name: mbus_cert
+- name: mbus_ca
   type: certificate
   options:
     is_ca: true
+    common_name: ca
+- name: mbus_cert
+  type: certificate
+  options:
+    ca: mbus_ca
     common_name: mbus
     alternative_names:
     - ((lan_ip))


### PR DESCRIPTION
It fails when using openvpn-clients because v4.0.0 doesn't have openvpn-clients job.