### PR TITLE
Proper iptables config properties

### DIFF
--- a/deployment/with-gateway-redirection.yml
+++ b/deployment/with-gateway-redirection.yml
@@ -11,9 +11,10 @@
     name: iptables
     release: networking
     properties:
-      nat:
-        POSTROUTING:
-        - -s ((vpn_network))/((vpn_network_mask_bits)) -d 0/0 -j MASQUERADE
+      iptables:
+        nat:
+          POSTROUTING:
+          - -s ((vpn_network))/((vpn_network_mask_bits)) -d 0/0 -j MASQUERADE
 - path: /instance_groups/name=openvpn/jobs/name=openvpn/properties/extra_configs?/-
   type: replace
   value: push "redirect-gateway def1"


### PR DESCRIPTION
per https://bosh.io/jobs/iptables?source=github.com/cloudfoundry/networking-release&version=9 , the `networking-release/iptables` job requires the `iptables` property, rather than the `nat` property directly. You can see this working when you do `iptables -t nat --list` on the subject VM.

Future PRs may include improvements to this ops file.