### PR TITLE
Fix compression param in the spec file

### DIFF
--- a/jobs/openvpn/spec
+++ b/jobs/openvpn/spec
@@ -76,7 +76,7 @@ properties:
     - auto
     - lzo
     - lz4
-    - lz4-2
+    - lz4-v2
   cipher:
     description: "Cipher for encrypting packets"
     default: "AES-256-CBC"


### PR DESCRIPTION
When attempting to specify `lz4-2` OpenVPN would fail to start with unknown compression options, changing to `lz4-v2` resolves this.