### PR TITLE
Prevent "too many arguments" error when building for Bionic

### DIFF
--- a/packages/openvpn/packaging
+++ b/packages/openvpn/packaging
@@ -7,8 +7,9 @@ cpus=$( grep -c ^processor /proc/cpuinfo )
 
 ( cd openssl
 
-  tar -xzf openssl-*.tar.gz
-  cd openssl-*
+  mkdir -p archive
+  tar -xzf openssl-*.tar.gz -C ./archive/
+  cd ./archive/openssl-*
 
   ./config \
     -DSSL_ALLOW_ADH \
@@ -22,8 +23,9 @@ cpus=$( grep -c ^processor /proc/cpuinfo )
 
 ( cd lzo
 
-  tar -xzf lzo-*.tar.gz
-  cd lzo-*
+  mkdir -p archive
+  tar -xzf lzo-*.tar.gz -C ./archive/
+  cd ./archive/lzo-*
 
   ./configure \
     --prefix=${BOSH_INSTALL_TARGET}/external/lzo \
@@ -34,8 +36,9 @@ cpus=$( grep -c ^processor /proc/cpuinfo )
 
 ( cd openvpn
 
-  tar -xzf openvpn-*.tar.gz
-  cd openvpn-*
+  mkdir -p archive
+  tar -xzf openvpn-*.tar.gz -C ./archive/
+  cd ./archive/openvpn-*
 
   export CFLAGS="-I${BOSH_INSTALL_TARGET}/external/openssl/include -Wl,-rpath=${BOSH_INSTALL_TARGET}/external/openssl/lib -L${BOSH_INSTALL_TARGET}/external/openssl/lib"
   export LZO_CFLAGS="-I${BOSH_INSTALL_TARGET}/external/lzo/include"


### PR DESCRIPTION
When packaging under Bionic the directory change using a wildcard results in an error since it matches both the .tar.gz file as well as the newly created directory.

```
+ cd openssl
+ tar -xzf openssl-1.1.1k.tar.gz
+ cd openssl-1.1.1k openssl-1.1.1k.tar.gz
packaging: line 11: cd: too many arguments
```